### PR TITLE
reconfigure the minimum request body data rate for kestrel

### DIFF
--- a/Robust.Cdn/Program.cs
+++ b/Robust.Cdn/Program.cs
@@ -12,6 +12,11 @@ using Robust.Cdn.Services;
 var builder = WebApplication.CreateBuilder(args);
 builder.Host.UseSystemd();
 
+builder.WebHost.ConfigureKestrel(o => {
+    o.Limits.MinRequestBodyDataRate = new MinDataRate(bytesPerSecond: 100, gracePeriod: TimeSpan.FromSeconds(30));
+});
+
+
 // Add services to the container.
 
 builder.Services.Configure<CdnOptions>(builder.Configuration.GetSection(CdnOptions.Position));


### PR DESCRIPTION
possibly required because github actions runner now always fails for this